### PR TITLE
https://github.com/mietek/haskell-on-heroku-website/issues/3

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -45,7 +45,7 @@ Need commercial support?  Contact the [author](#about) directly.
 
 ### Examples
 
-Haskell on Heroku is being used in production since June 2014.
+Haskell on Heroku has been used in production since June 2014.
 
 All Halcyon [example applications](https://halcyon.sh/examples/) and [“Hello, world!” shootout entries](https://halcyon.sh/shootout/) can be deployed to Heroku just by pushing a button.
 


### PR DESCRIPTION
issue tracker: https://github.com/mietek/haskell-on-heroku-website/issues/3

The sentence "Haskell on Heroku is being used in production since June 2014." should read: "Haskell on Heroku has been used in production since June 2014."

see http://www.englishpage.com/verbpage/presentperfectcontinuous.html
